### PR TITLE
Connector hub improvements

### DIFF
--- a/src/fixtures/connector-hub-data.ts
+++ b/src/fixtures/connector-hub-data.ts
@@ -36,7 +36,7 @@ export const CONNECTOR_HUB_DATA: ConnectorModal[] = [
     revisionVersion: 0,
   },
   {
-    typeId: 1,
+    typeId: 2,
     authorizationType: 'None',
     name: 'Slack Channel',
     resource: 'channel',

--- a/src/fixtures/connector-type-data.ts
+++ b/src/fixtures/connector-type-data.ts
@@ -1,0 +1,9 @@
+interface TypeModel {
+    id: number;
+    name: string;
+}
+export const TYPE_NAMES_DATA: TypeModel[] = [
+    { id: 1, name: 'Foundation' },
+    { id: 2, name: 'CRM' },
+    { id: 3, name: 'Talent' },
+];

--- a/src/fixtures/connector-type-data.ts
+++ b/src/fixtures/connector-type-data.ts
@@ -1,9 +1,0 @@
-interface TypeModel {
-    id: number;
-    name: string;
-}
-export const TYPE_NAMES_DATA: TypeModel[] = [
-    { id: 1, name: 'Foundation' },
-    { id: 2, name: 'CRM' },
-    { id: 3, name: 'Talent' },
-];

--- a/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
+++ b/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
@@ -4,7 +4,16 @@ import { ConnectorCard } from '../connector-card';
 import { StyledCard, StyledMeta } from '../connector-card.css';
 import { Row, Col, Tag, Card } from 'antd';
 import { ConnectorModal } from '../../../../../redux/connector-hub/types';
-import { TYPE_NAMES_DATA } from '../../../../../fixtures/connector-type-data';
+
+interface TypeModel {
+  id: number;
+  name: string;
+}
+export const TYPE_NAMES_DATA: TypeModel[] = [
+  { id: 1, name: 'Foundation' },
+  { id: 2, name: 'CRM' },
+  { id: 3, name: 'Talent' },
+];
 
 describe('ConnectorCard', () => {
   const connector = (overrides: object = {}): ConnectorModal => ({

--- a/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
+++ b/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
@@ -2,8 +2,9 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { ConnectorCard } from '../connector-card';
 import { StyledCard, StyledMeta } from '../connector-card.css';
-import { Row, Col } from 'antd';
+import { Row, Col, Tag, Card } from 'antd';
 import { ConnectorModal } from '../../../../../redux/connector-hub/types';
+import { TYPE_NAMES_DATA } from '../../../../../fixtures/connector-type-data';
 
 describe('ConnectorCard', () => {
   const connector = (overrides: object = {}): ConnectorModal => ({
@@ -49,4 +50,12 @@ describe('ConnectorCard', () => {
     expect(columns.at(0).text()).toEqual('ERN');
     expect(columns.at(1).text()).toEqual(connector().ern);
   });
+
+  it('renders a tag with typeId', () => {
+    const tags = this.connectorCard.find(Tag);
+    expect(this.connectorCard.find(Card)).toHaveLength(1);
+    expect(tags).toHaveLength(1);
+    expect(tags.at(0).text()).toEqual(TYPE_NAMES_DATA.find(myObj => myObj.id === connector().typeId).name);
+  });
+  
 });

--- a/src/modules/connector-hub/components/card-collection/connector-card.css.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.css.tsx
@@ -33,7 +33,7 @@ export const ErnCol = styled(Col as any)`
 
 export const ButtonContainer = styled.div`
   text-align: center;
-  margin: 20px;
+  margin-top: 20px;
 `;
 
 export const ErnValue = styled.span`

--- a/src/modules/connector-hub/components/card-collection/connector-card.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.tsx
@@ -12,22 +12,13 @@ import {
 } from './connector-card.css';
 
 import { ConnectorModal } from '../../../../redux/connector-hub/types';
+import { TYPE_NAMES_DATA } from '../../../../fixtures/connector-type-data';
 
 interface CompanyImageComponentProps {
   image: string;
 }
 
 const companyImageMockUrl: string = 'salesforce_logo_detail.png';
-
-interface TypeModel {
-  id: number;
-  name: string;
-}
-const typeNames: TypeModel[] = [
-  { id: 1, name: 'Foundation' },
-  { id: 2, name: 'CRM' },
-  { id: 3, name: 'Talent' },
-];
 
 const CompanyImageComponent: React.SFC<CompanyImageComponentProps> = ({
   image,
@@ -51,7 +42,7 @@ export class ConnectorCard extends React.Component<ConnectorCardProps> {
         hoverable
         title={connector.name}
         cover={<CompanyImageComponent image={companyImageMockUrl} />}
-        extra={<Tag color="green">{typeNames.find(myObj => myObj.id === connector.typeId).name}</Tag>}
+        extra={<Tag color="green">{TYPE_NAMES_DATA.find(myObj => myObj.id === connector.typeId).name}</Tag>}
       >
         <StyledMeta description={connector.properties.description} />
         <Row>

--- a/src/modules/connector-hub/components/card-collection/connector-card.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.tsx
@@ -19,6 +19,15 @@ interface CompanyImageComponentProps {
 
 const companyImageMockUrl: string = 'salesforce_logo_detail.png';
 
+interface TypeModel {
+  id: number;
+  name: string;
+}
+const typeNames: TypeModel[] = [
+  { id: 1, name: 'Talent' },
+  { id: 2, name: 'Foundation' },
+];
+
 const CompanyImageComponent: React.SFC<CompanyImageComponentProps> = ({
   image,
 }: CompanyImageComponentProps) => {
@@ -41,7 +50,7 @@ export class ConnectorCard extends React.Component<ConnectorCardProps> {
         hoverable
         title={connector.name}
         cover={<CompanyImageComponent image={companyImageMockUrl} />}
-        extra={<Tag color="green">{connector.typeId}</Tag>}
+        extra={<Tag color="green">{typeNames.find(myObj => myObj.id === connector.typeId).name}</Tag>}
       >
         <StyledMeta description={connector.properties.description} />
         <Row>

--- a/src/modules/connector-hub/components/card-collection/connector-card.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Col, Row, Tag } from 'antd';
+import { Col, Row, Tag, Button } from 'antd';
 
 import {
   CompanyImage,
@@ -11,7 +11,6 @@ import {
   ImageContainer,
 } from './connector-card.css';
 
-import { StyledButton } from '../../../ui-kit/button';
 import { ConnectorModal } from '../../../../redux/connector-hub/types';
 
 interface CompanyImageComponentProps {
@@ -52,9 +51,7 @@ export class ConnectorCard extends React.Component<ConnectorCardProps> {
           </Col>
         </Row>
         <ButtonContainer>
-          <StyledButton icon="key" type="primary">
-            Configure Collections
-          </StyledButton>
+          <Button type="primary" size="large">Configure</Button>
         </ButtonContainer>
       </StyledCard>
     );

--- a/src/modules/connector-hub/components/card-collection/connector-card.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.tsx
@@ -12,13 +12,21 @@ import {
 } from './connector-card.css';
 
 import { ConnectorModal } from '../../../../redux/connector-hub/types';
-import { TYPE_NAMES_DATA } from '../../../../fixtures/connector-type-data';
 
 interface CompanyImageComponentProps {
   image: string;
 }
-
 const companyImageMockUrl: string = 'salesforce_logo_detail.png';
+
+interface TypeModel {
+  id: number;
+  name: string;
+}
+export const TYPE_NAMES_DATA: TypeModel[] = [
+  { id: 1, name: 'Foundation' },
+  { id: 2, name: 'CRM' },
+  { id: 3, name: 'Talent' },
+];
 
 const CompanyImageComponent: React.SFC<CompanyImageComponentProps> = ({
   image,

--- a/src/modules/connector-hub/components/card-collection/connector-card.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.tsx
@@ -24,8 +24,9 @@ interface TypeModel {
   name: string;
 }
 const typeNames: TypeModel[] = [
-  { id: 1, name: 'Talent' },
-  { id: 2, name: 'Foundation' },
+  { id: 1, name: 'Foundation' },
+  { id: 2, name: 'CRM' },
+  { id: 3, name: 'Talent' },
 ];
 
 const CompanyImageComponent: React.SFC<CompanyImageComponentProps> = ({

--- a/src/modules/connector-hub/containers/__tests__/connector-hub.container.test.tsx
+++ b/src/modules/connector-hub/containers/__tests__/connector-hub.container.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Spin } from 'antd';
+import { ConnectorHub } from '../connector-hub.container';
+import { ConnectorHubComponent } from '../../components/connector-hub/connector-hub';
+import { CONNECTOR_HUB_DATA } from '../../../../fixtures/connector-hub-data';
+
+describe('Connector Hub Container', () => {
+  const fetchConnectorsMock = jest.fn();
+
+  beforeEach(() => {
+    this.container = mount(
+      <ConnectorHub 
+        loading
+        connectors={CONNECTOR_HUB_DATA}
+        fetchConnectors={fetchConnectorsMock}
+      />
+    );
+  });
+
+  it('calls fetchConnectors', () => {
+    expect(fetchConnectorsMock).toBeCalled();
+  });
+
+  it('sets loading property on Spin component', () => {
+    expect(this.container.find(Spin).prop('spinning')).toBeTruthy();
+  });
+
+  it('renders connector hub component with Spin component', () => {
+    expect(this.container.find(Spin).find(ConnectorHubComponent)).toHaveLength(1);
+  });
+
+  it('passes login action to login component', () => {
+    expect(
+      this.container
+        .find(Spin)
+        .find(ConnectorHubComponent)
+        .prop('connectors')
+    ).toEqual(CONNECTOR_HUB_DATA);
+  });
+
+});

--- a/src/modules/connector-hub/containers/connector-hub.container.tsx
+++ b/src/modules/connector-hub/containers/connector-hub.container.tsx
@@ -29,7 +29,7 @@ type AllProps = PropsFromState & PropsFromDispatch;
 
 export class ConnectorHub extends Component<AllProps> {
   componentDidMount = () => {
-    //   this.props.fetchConnectors();
+      this.props.fetchConnectors();
   };
 
   public render() {

--- a/src/redux/connector-hub/reducer.ts
+++ b/src/redux/connector-hub/reducer.ts
@@ -2,12 +2,11 @@ import { Reducer } from 'redux';
 import { ConnectorHubState } from './types';
 import { ActionType, getType } from 'typesafe-actions';
 import * as actions from './actions';
-import { CONNECTOR_HUB_DATA } from '../../fixtures/connector-hub-data';
 
 export type ConnectorHubActionType = ActionType<typeof actions>;
 
 const initialState: ConnectorHubState = {
-  data: CONNECTOR_HUB_DATA,
+  data: [],
   loading: false,
 };
 


### PR DESCRIPTION
## [MAIN-208](https://electricaio.atlassian.net/browse/MAIN-208)

## Description

1. The button should just be called `Configure` instead of `Configure Collections`
2. Remove the search icon
3. The badge next to the title should be the type display name. 
4. Fetch connectors from the API not from a mock file.
