### PR TITLE
Main 179

### DIFF
--- a/src/modules/connector-hub/components/card-collection/__tests__/card-collection.test.tsx
+++ b/src/modules/connector-hub/components/card-collection/__tests__/card-collection.test.tsx
@@ -4,6 +4,7 @@ import times from 'lodash/times';
 import { CardCollection } from '../card-collection';
 import { ConnectorCard } from '../connector-card';
 import { ConnectorModal } from '../../../../../redux/connector-hub/types';
+import { MemoryRouter } from 'react-router';
 
 describe('CardCollection', () => {
   const connectorCount = 3;
@@ -29,7 +30,11 @@ describe('CardCollection', () => {
   }
 
   beforeEach(() => {
-    this.CardCollection = mount(<CardCollection connectors={createConnectors(connectorCount)} />);
+    this.CardCollection = mount(
+      <MemoryRouter>
+        <CardCollection connectors={createConnectors(connectorCount)} />
+      </MemoryRouter>
+    );
   });
 
   it('should show number of cards as connectors', () => {

--- a/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
+++ b/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
@@ -2,8 +2,10 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { ConnectorCard } from '../connector-card';
 import { StyledCard, StyledMeta } from '../connector-card.css';
-import { Row, Col, Tag, Card } from 'antd';
+import { Row, Col, Tag, Card, Button } from 'antd';
 import { ConnectorModal } from '../../../../../redux/connector-hub/types';
+import { MemoryRouter } from 'react-router';
+import { Link } from 'react-router-dom';
 
 interface TypeModel {
   id: number;
@@ -16,6 +18,7 @@ export const TYPE_NAMES_DATA: TypeModel[] = [
 ];
 
 describe('ConnectorCard', () => {
+  const connectorId = 4;
   const connector = (overrides: object = {}): ConnectorModal => ({
     typeId: 1,
     authorizationType: 'None',
@@ -29,14 +32,18 @@ describe('ConnectorCard', () => {
       image_url: 'string',
       description: 'This connector allows you to connect to SalesForce CRM system.',
     },
-    id: 4,
+    id: connectorId,
     ern: 'ern://salesforce:customer:2_0',
     revisionVersion: 0,
     ...overrides,
   });
 
   beforeEach(() => {
-    this.connectorCard = mount(<ConnectorCard connector={connector()} />);
+    this.connectorCard = mount(
+      <MemoryRouter>
+        <ConnectorCard connector={connector()} />
+      </MemoryRouter>
+    );
   });
 
   it('card contains connector name as a title', () => {
@@ -66,6 +73,13 @@ describe('ConnectorCard', () => {
     expect(tags).toHaveLength(1);
     expect(tags.at(0).text()).toEqual(
       TYPE_NAMES_DATA.find(myObj => myObj.id === connector().typeId).name
+    );
+  });
+
+  it('renders a Link in the button for routing to the connections page', () => {
+    const configureButton = this.connectorCard.find(Button);
+    expect(configureButton.find(Link).prop('to')).toEqual(
+      `/connector-hub/${connectorId}/connections`
     );
   });
 });

--- a/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
+++ b/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
@@ -79,7 +79,7 @@ describe('ConnectorCard', () => {
   it('renders a Link in the button for routing to the connections page', () => {
     const configureButton = this.connectorCard.find(Button);
     expect(configureButton.find(Link).prop('to')).toEqual(
-      `/connector-hub/${connectorId}/connections`
+      `/connector-hub/${connectorId}`
     );
   });
 });

--- a/src/modules/connector-hub/components/card-collection/connector-card.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Col, Row, Tag, Button } from 'antd';
+import { Link } from 'react-router-dom';
 
 import {
   CompanyImage,
@@ -65,7 +66,7 @@ export class ConnectorCard extends React.Component<ConnectorCardProps> {
         </Row>
         <ButtonContainer>
           <Button type="primary" size="large">
-            Configure
+            <Link to={`/connector-hub/${connector.id}/connections`}>Configure</Link>
           </Button>
         </ButtonContainer>
       </StyledCard>

--- a/src/modules/connector-hub/components/card-collection/connector-card.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.tsx
@@ -66,7 +66,7 @@ export class ConnectorCard extends React.Component<ConnectorCardProps> {
         </Row>
         <ButtonContainer>
           <Button type="primary" size="large">
-            <Link to={`/connector-hub/${connector.id}/connections`}>Configure</Link>
+            <Link to={`/connector-hub/${connector.id}`}>Configure</Link>
           </Button>
         </ButtonContainer>
       </StyledCard>

--- a/src/modules/connector-hub/components/connector-hub/__tests__/connector-hub.test.tsx
+++ b/src/modules/connector-hub/components/connector-hub/__tests__/connector-hub.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ConnectorHubComponent } from '../connector-hub';
+import { Header } from '../../header/header';
+import { CardCollection } from '../../card-collection/card-collection';
+import { CONNECTOR_HUB_DATA } from '../../../../../fixtures/connector-hub-data';
+
+describe('Connector Hub component', () => {
+  beforeEach(() => {
+    this.container = shallow(<ConnectorHubComponent connectors={CONNECTOR_HUB_DATA} />);
+  });
+
+  it('renders Header', () => {
+    expect(this.container.find(Header)).toHaveLength(1);
+  });
+
+  it('renders a CardCollection with the connectors', () => {
+    const component = this.container.find(CardCollection);
+    expect(component).toHaveLength(1);
+    expect(component.prop('connectors')).toEqual(CONNECTOR_HUB_DATA);
+  });
+});

--- a/src/modules/connector-hub/containers/__tests__/connector-hub.container.test.tsx
+++ b/src/modules/connector-hub/containers/__tests__/connector-hub.container.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { Spin } from 'antd';
 import { ConnectorHub } from '../connector-hub.container';
 import { ConnectorHubComponent } from '../../components/connector-hub/connector-hub';
@@ -9,7 +9,7 @@ describe('Connector Hub Container', () => {
   const fetchConnectorsMock = jest.fn();
 
   beforeEach(() => {
-    this.container = mount(
+    this.container = shallow(
       <ConnectorHub loading connectors={CONNECTOR_HUB_DATA} fetchConnectors={fetchConnectorsMock} />
     );
   });

--- a/src/routes/__tests__/dashboard.test.tsx
+++ b/src/routes/__tests__/dashboard.test.tsx
@@ -40,8 +40,8 @@ describe('Dashboard', () => {
     expect(routeComponent('/connector-hub')).toBe(ConntectorHubContainer);
   });
 
-  it('routes /connector-hub/:connectorId/connections to ConnectionsContainer', () => {
-    expect(routeComponent('/connector-hub/:connectorId/connections')).toBe(ConnectionsContainer);
+  it('routes /connector-hub/:connectorId to ConnectionsContainer', () => {
+    expect(routeComponent('/connector-hub/:connectorId')).toBe(ConnectionsContainer);
   });
 
   describe('PrivateRoute', () => {

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -51,7 +51,7 @@ export const PrivateDashboard: React.SFC<PropsFromDispatch> = ({ isAuthenticated
         />
         <PrivateRoute
           isAuthenticated={isAuthenticated}
-          path="/connector-hub/:connectorId/connections"
+          path="/connector-hub/:connectorId"
           component={ConnectionsContainer}
         />
       </Switch>


### PR DESCRIPTION
## [MAIN-179](https://electricaio.atlassian.net/browse/MAIN-179)

## Description

When a user clicks on a connector in the hub it should take them to the connections page.
We should use the breadcrumb component to go back to the connector hub.
We should use react router to navigate between these two screens