### PR TITLE
Removing access key selection when editing a connection

### DIFF
--- a/src/modules/connections/components/__tests__/connections.test.tsx
+++ b/src/modules/connections/components/__tests__/connections.test.tsx
@@ -11,8 +11,12 @@ import { ConnectionForm } from '../connection-form/connection-form';
 import { StyledButton } from '../../../ui-kit/button';
 
 describe('connections', () => {
+  const authorizationId = 2;
+  const connectionId = 2123;
   const connections: ConnectionModal[] = [
     {
+      authorizationId,
+      id: connectionId,
       name: 'Uber',
       accessKeyId: 1,
       connectorId: 1,
@@ -49,6 +53,11 @@ describe('connections', () => {
   const connectorToken: ConnectorModal = {
     ...connectorBasic,
     authorizationType: 'Token',
+  };
+
+  const noAuthorization: ConnectorModal = {
+    ...connectorBasic,
+    authorizationType: 'None',
   };
 
   const connectionName = 'Test Connection';
@@ -166,7 +175,7 @@ describe('connections', () => {
     expect(createConnectionMock).toBeCalledWith(connectionValue, connectorToken, tokenCreds);
   });
 
-  it('handleEdit calls updateConnection with updated connection', () => {
+  it('handleEdit calls updateConnection with updated connection', async () => {
     const component = createConnectionComponent({ connector: connectorToken });
     const accessKeyId = 10;
 
@@ -183,9 +192,51 @@ describe('connections', () => {
       name: connectionName,
     };
 
-    const connectionId = 123;
-    (component.instance() as any).handleEdit(connectionId, formValues);
+    await (component.instance() as any).handleEdit(connectionId, formValues);
     expect(updateConnectionMock).toBeCalledWith(connectionId, connectionValue);
+  });
+
+  it('handleEdit calls updateAuthorization', async () => {
+    const component = createConnectionComponent({ connector: connectorToken });
+    const accessKeyId = 10;
+
+    const formValues: any = {
+      accessKeyId,
+      connectionName,
+      properties: [],
+    };
+
+    await (component.instance() as any).handleEdit(connectionId, formValues).then;
+    expect(updateAuthorizationMock).toBeCalled();
+  });
+
+  it('handleEdit does not call updateAuthorization if there is no authorization', async () => {
+    const component = createConnectionComponent({ connector: noAuthorization });
+    const accessKeyId = 10;
+
+    const formValues: any = {
+      accessKeyId,
+      connectionName,
+      properties: [],
+    };
+
+    await (component.instance() as any).handleEdit(connectionId, formValues);
+    expect(updateAuthorizationMock).not.toBeCalled();
+  });
+
+  it('handleEdit uses access key property from connection if the form value is undefined', async () => {
+    const component = createConnectionComponent({ connector: noAuthorization });
+
+    const formValues: any = {
+      connectionName,
+      accessKeyId: undefined,
+      properties: [],
+    };
+
+    await (component.instance() as any).handleEdit(connectionId, formValues);
+    expect(updateConnectionMock ).toBeCalledWith(connectionId, expect.objectContaining({
+      accessKeyId: connections[0].accessKeyId,
+    }));
   });
 
   it('handleCommit calls createConnection with properties', () => {

--- a/src/modules/connections/components/connection-form/__tests__/connection-form.test.tsx
+++ b/src/modules/connections/components/connection-form/__tests__/connection-form.test.tsx
@@ -47,6 +47,19 @@ describe('ConnectionForm', () => {
     expect(select).toHaveLength(1);
   });
 
+  describe('editMode', () => {
+    beforeEach(() => {
+      this.editModeConnectionForm = mount(
+        <ConnectionForm accessKeys={accessKeys} connector={connector} inEditMode />
+      );
+    });
+
+    it('does not show access keys component if in edit mode', () => {
+      const accessKeysComponent = this.connectionForm.find('input#accessKeyId');
+      expect(accessKeysComponent).toHaveLength(0);
+    });
+  });
+
   describe('SelectAccessKeys', () => {
     it('render select with options', () => {
       const selectAccessKeysComponent = shallow(<SelectAccessKeys accessKeys={accessKeys} />);

--- a/src/modules/connections/components/connection-form/connection-form.tsx
+++ b/src/modules/connections/components/connection-form/connection-form.tsx
@@ -8,6 +8,7 @@ import { ConnectorModal } from '../../../../redux/connector-hub/types';
 import { SelectProps } from 'antd/lib/select';
 import { PropertiesForm, Properties } from '../../../../components/properties-form/properties-form';
 import { AuthorizationType } from '../../../../redux/connections/types';
+import { isBasicAuthorizationType, isTokenAuthorizationType } from '../../../../utils';
 
 const FormItem = Form.Item;
 const Option = Select.Option;
@@ -15,6 +16,7 @@ const Option = Select.Option;
 interface ConnectionComponentProps extends FormComponentProps {
   connector: ConnectorModal;
   accessKeys: ApiKeyModal[];
+  inEditMode?: boolean;
   defaultFormValues?: DefaultFormValues;
 }
 
@@ -68,7 +70,9 @@ class ConnectionFormComponent extends Component<ConnectionComponentProps> {
       connector,
       defaultFormValues,
       form: { getFieldDecorator },
+      inEditMode = false,
     } = this.props;
+
     return (
       <Form>
         <FormItem>
@@ -77,13 +81,15 @@ class ConnectionFormComponent extends Component<ConnectionComponentProps> {
             rules: [{ required: true, message: 'Please input a name for this connection' }],
           })(<StyledInput placeholder="Connection Name" />)}
         </FormItem>
-        <FormItem>
-          {getFieldDecorator('accessKeyId', {
-            initialValue: defaultFormValues.accessKeyId,
-            rules: [{ required: true, message: 'Please select an access key', type: 'number' }],
-          })(<SelectAccessKeys accessKeys={accessKeys} />)}
-        </FormItem>
-        {connector.authorizationType === 'Basic' && (
+        {!inEditMode && (
+          <FormItem >
+            {getFieldDecorator('accessKeyId', {
+              initialValue: defaultFormValues.accessKeyId,
+              rules: [{ required: true, message: 'Please select an access key', type: 'number' }],
+            })(<SelectAccessKeys accessKeys={accessKeys} />)}
+          </FormItem>
+        )}
+        {isBasicAuthorizationType(connector.authorizationType) && (
           <Fragment>
             <FormItem>
               {getFieldDecorator('username', {
@@ -99,7 +105,7 @@ class ConnectionFormComponent extends Component<ConnectionComponentProps> {
             </FormItem>
           </Fragment>
         )}
-        {connector.authorizationType === 'Token' && (
+        {isTokenAuthorizationType(connector.authorizationType) && (
           <FormItem>
             {getFieldDecorator('token', {
               initialValue: defaultFormValues.authorization.token,

--- a/src/modules/connections/components/table/table.tsx
+++ b/src/modules/connections/components/table/table.tsx
@@ -9,7 +9,7 @@ import { SelectValue } from 'antd/lib/select';
 import { DateComponent } from '../../../ui-kit/date';
 import { Link } from 'react-router-dom';
 import { ConnectorModal } from '../../../../redux/connector-hub/types';
-import { ConnectionFormContainer } from '../../containers/connection-form.container';
+import { ConnectionFormContainer } from '../../containers/edit-connection-form.container';
 
 const Option = Select.Option;
 

--- a/src/modules/connections/containers/__tests__/edit-connection-form.container.test.tsx
+++ b/src/modules/connections/containers/__tests__/edit-connection-form.container.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { AsyncComponent } from '../../../../components/async-component/async-component';
-import { ConnectionFormComponent } from '../connection-form.container';
+import { ConnectionFormComponent } from '../edit-connection-form.container';
 import { ConnectionModal } from '../../../../redux/connections/types';
 import { ConnectorModal } from '../../../../redux/connector-hub/types';
 import { ApiKeyModal } from '../../../../redux/api-keys/types';
@@ -74,7 +74,7 @@ describe('Connector Form Container', () => {
       const actions = this.component.find(AsyncComponent).prop('getAsyncActions');
       actions();
       expect(fetchAuthorizationMock).toBeCalledWith(
-        testConnection.id,
+        testConnection.authorizationId,
         testConnector.authorizationType
       );
     });
@@ -88,6 +88,14 @@ describe('Connector Form Container', () => {
           .find(ConnectionForm)
           .prop('connector')
       ).toEqual(testConnector);
+    });
+    it('passes edit mode flag', () => {
+      expect(
+        this.component
+          .find(AsyncComponent)
+          .find(ConnectionForm)
+          .prop('inEditMode')
+      ).toBeTruthy();
     });
 
     it('passes access keys', () => {

--- a/src/modules/connections/containers/edit-connection-form.container.tsx
+++ b/src/modules/connections/containers/edit-connection-form.container.tsx
@@ -45,7 +45,9 @@ export class ConnectionFormComponent extends Component<AllProps> {
       accessKeys,
       wrappedComponentRef,
     } = this.props;
-    const asyncActions = () => [fetchAuthorization(connection.id, connector.authorizationType)];
+    const asyncActions = () => [
+      fetchAuthorization(connection.authorizationId, connector.authorizationType),
+    ];
 
     const authorization = authorizations.find(
       (auth: AuthorizationType) => auth.id === connection.authorizationId
@@ -70,6 +72,7 @@ export class ConnectionFormComponent extends Component<AllProps> {
           defaultFormValues={defaultValues}
           connector={connector}
           accessKeys={accessKeys}
+          inEditMode
         />
       </AsyncComponent>
     );

--- a/src/modules/ui-kit/modal-button-action/modal-button-action.tsx
+++ b/src/modules/ui-kit/modal-button-action/modal-button-action.tsx
@@ -27,8 +27,10 @@ export class ButtonActionModal extends Component<TConnectionsProps, TConnections
   };
 
   closeModal = () => {
-    const form = this.formRef.props.form;
-    form.resetFields();
+    if (this.formRef) {
+      const form = this.formRef.props.form;
+      form.resetFields();
+    }
 
     this.setState({
       visible: false,

--- a/src/redux/connections/__tests__/async.test.ts
+++ b/src/redux/connections/__tests__/async.test.ts
@@ -43,7 +43,7 @@ describe('Connection Async Actions', () => {
   const testConnector: ConnectorModal = {
     id: 4,
     typeId: 1,
-    authorizationType: 'None',
+    authorizationType: 'Basic',
     name: 'SalesForce CRM API 2.0',
     version: '2.0',
     namespace: 'salesforce',
@@ -95,6 +95,12 @@ describe('Connection Async Actions', () => {
       const successDispatchCall = dispatchMock.mock.calls[0][0];
 
       expect(successDispatchCall.payload).toEqual(testConnectionResult);
+    });
+
+    it('does not call createConnectionAuthorization if there is no authorization', async () => {
+      testConnector.authorizationType = 'None';
+      await createConnection(testConnection, testConnector, testAuthType)(dispatchMock);
+      expect(mockApi.createConnectionAuthorization).not.toBeCalled();
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export const isTokenAuthorizationType = (authorizationType: string) => {
+  return authorizationType.toLowerCase() === 'token';
+};
+
+export const isBasicAuthorizationType = (authorizationType: string) => {
+  return authorizationType.toLowerCase() === 'basic';
+};
+
+export const hasNoAuthorizationType = (authorizationType: string) => {
+  return authorizationType.toLowerCase() === 'none';
+};


### PR DESCRIPTION
<!--- Title Link to Jira Ticket --->
## [MAIN-265](https://electricaio.atlassian.net/browse/MAIN-265)


 <!--- Provide a summary of the changes --->
## Description
Removing access key selection when editing a connection
Preventing updating and creating of connection auth if authorization type is "None"