### PR TITLE
rendering the connector card even if there is no description

### DIFF
--- a/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
+++ b/src/modules/connector-hub/components/card-collection/__tests__/connector-card.test.tsx
@@ -95,4 +95,15 @@ describe('ConnectorCard', () => {
       expect(imageContainer.find(CompanyImage).prop('src')).toEqual(image);
     });
   });
+
+  describe('card with no properties', () => {
+    it('renders', () => {
+      const connectorCard = mount(
+        <MemoryRouter>
+          <ConnectorCard connector={connector({ properties: undefined })} />
+        </MemoryRouter>
+      );
+      expect(connectorCard.find(StyledMeta)).toHaveLength(1);
+    });
+  });
 });

--- a/src/modules/connector-hub/components/card-collection/connector-card.tsx
+++ b/src/modules/connector-hub/components/card-collection/connector-card.tsx
@@ -45,6 +45,7 @@ type ConnectorCardProps = {
 export class ConnectorCard extends React.Component<ConnectorCardProps> {
   render() {
     const { connector } = this.props;
+    const { description = '' } = connector.properties || {};
     return (
       <StyledCard
         hoverable
@@ -56,7 +57,7 @@ export class ConnectorCard extends React.Component<ConnectorCardProps> {
           </Tag>
         }
       >
-        <StyledMeta description={connector.properties.description} />
+        <StyledMeta description={description} />
         <Row>
           <ErnCol span={4}>ERN</ErnCol>
           <Col span={8}>


### PR DESCRIPTION
<!--- Title Link to Jira Ticket --->
## [MAIN-280](https://electricaio.atlassian.net/browse/MAIN-280)


 <!--- Provide a summary of the changes --->
## Description
Description is optional in a connector so ensuring the connector still renders